### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-<h1 align="center"><b>NoiseGrad and FusdionGrad</b></h1>
+<h1 align="center"><b>NoiseGrad and FusionGrad</b></h1>
 <h3 align="center"><b>NoiseGrad: enhancing explanations by introducing stochasticity to model weights</b></h3>
 <p align="center">
   <i>Pytorch implementation</i>
-</p> 
- 
+</p>
+
 --------------
 
 Pytorch implementation for **"NoiseGrad: enhancing explanations by introducing stochasticity to model weights"**. The paper introduces two novel methods `NoiseGrad` and `FusionGrad` which both improves attribution-based explanations by introducing stochasticity to the model parameters. See arXiv preprint: https://arxiv.org/abs/2106.10185.
 
 <p align="center">
-  <img src="samples/resulting_explanation.png" alt="Visualization of baseline, NoiseGrad and NoiseGrad++ explanations using (Integrated Gradient) as XAI method." width="512"/>  
+  <img src="samples/resulting_explanation.png" alt="Visualization of baseline, NoiseGrad and NoiseGrad++ explanations using (Integrated Gradient) as XAI method." width="512"/>
 </p>
 
 ## Cite this paper
@@ -17,7 +17,7 @@ Pytorch implementation for **"NoiseGrad: enhancing explanations by introducing s
 To cite this paper use following Bibtex annotation:
 
 	@misc{bykov2021noisegrad,
-	      title={NoiseGrad: enhancing explanations by introducing stochasticity to model weights}, 
+	      title={NoiseGrad: enhancing explanations by introducing stochasticity to model weights},
 	      author={Kirill Bykov and Anna Hedström and Shinichi Nakajima and Marina M. -C. Höhne},
 	      year={2021},
 	      eprint={2106.10185},


### PR DESCRIPTION
Hey Anna and Kirill,

just found a little typo while scrolling.
Here are the changes:

- headline in README.md: FusdionGrad -> FusionGrad
- removed some trailing whitespaces in README.md while at it